### PR TITLE
fix/get teachers

### DIFF
--- a/app/dao/dao_test.go
+++ b/app/dao/dao_test.go
@@ -1012,3 +1012,18 @@ func TestClassSelection(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, class)
 }
+
+// check if a list of teachers can be extracted from a prefilled mock provider to check for role id bugs
+func TestGetTeachersForMeta(t *testing.T) {
+	provider := db.NewPrefilledMockProvider()
+
+	userDao := NewUserDao(repository.NewUserRepository(provider), repository.NewRoleRepository(provider))
+
+	err := userDao.CreateDefaults() // create the roles
+	require.Nil(t, err)
+
+	// Get all Teachers
+	teachers, err := userDao.GetTeachers()
+	require.Nil(t, err)
+	require.NotEmpty(t, teachers)
+}

--- a/app/db/mock.go
+++ b/app/db/mock.go
@@ -15,11 +15,11 @@ func prefillMockDB(p Provider) error {
 	mocks := []Mock{
 		{
 			Table:  "roles",
-			Entity: &Role1,
+			Entity: &RoleStudent,
 		},
 		{
 			Table:  "roles",
-			Entity: &Role2,
+			Entity: &RoleDozent,
 		},
 		{
 			Table:  "users",
@@ -192,17 +192,26 @@ func prefillMockDB(p Provider) error {
 	return nil
 }
 
-var Role1 = models.Role{
+var RoleStudent = models.Role{
 	Basemodel: models.Basemodel{
-		ID: 1,
+		ID: 4,
 	},
 	Description: "Student",
+	Claim:       "Student",
 }
-var Role2 = models.Role{
+var RoleDozent = models.Role{
+	Basemodel: models.Basemodel{
+		ID: 3,
+	},
+	Description: "Dozent",
+	Claim:       "Dozent",
+}
+var RoleFieldmanager = models.Role{
 	Basemodel: models.Basemodel{
 		ID: 2,
 	},
-	Description: "Dozent",
+	Description: "Fachbereichsleiter",
+	Claim:       "Fachbereichsleiter",
 }
 
 var User1 = models.User{
@@ -212,7 +221,7 @@ var User1 = models.User{
 	Name:  "Kurt Munter",
 	Email: "kurt.munter@hftm.ch",
 	Roles: []*models.Role{
-		&Role2,
+		&RoleDozent, &RoleFieldmanager,
 	},
 }
 var User2 = models.User{
@@ -223,7 +232,7 @@ var User2 = models.User{
 	Email:          "jakob.ferber@hftm.ch",
 	ClassStartyear: time.Date(2021, time.April, 1, 12, 0, 0, 0, time.UTC),
 	Roles: []*models.Role{
-		&Role1,
+		&RoleStudent,
 	},
 }
 var User3 = models.User{
@@ -234,7 +243,7 @@ var User3 = models.User{
 	Email:          "rafael.stauffer@hftm.ch",
 	ClassStartyear: time.Date(2021, time.April, 1, 12, 0, 0, 0, time.UTC),
 	Roles: []*models.Role{
-		&Role1,
+		&RoleStudent,
 	},
 }
 var User4 = models.User{
@@ -244,7 +253,7 @@ var User4 = models.User{
 	Name:  "Bruno Borer",
 	Email: "bruno.borer@hftm.ch",
 	Roles: []*models.Role{
-		&Role2,
+		&RoleDozent,
 	},
 }
 var User5 = models.User{
@@ -254,7 +263,7 @@ var User5 = models.User{
 	Name:  "Simeon Liniger",
 	Email: "simeon.liniger@hftm.ch",
 	Roles: []*models.Role{
-		&Role2,
+		&RoleDozent,
 	},
 }
 

--- a/app/repository/role_test.go
+++ b/app/repository/role_test.go
@@ -12,7 +12,7 @@ import (
 func Test_Role_Create(t *testing.T) {
 	repository := NewRoleRepository(db.NewPrefilledMockProvider())
 
-	role_1 := db.Role1
+	role_1 := db.RoleStudent
 	role_1.ID = 0
 
 	_, err := repository.Create(&role_1)
@@ -24,7 +24,7 @@ func Test_Role_Update(t *testing.T) {
 	repository := NewRoleRepository(db.NewPrefilledMockProvider())
 
 	// Update Description of Role
-	role := db.Role1
+	role := db.RoleStudent
 	role.Description = "edited description Role 1"
 	err := repository.Update(&role)
 
@@ -40,11 +40,11 @@ func Test_Role_Find(t *testing.T) {
 	repository := NewRoleRepository(db.NewPrefilledMockProvider())
 
 	// Find Role
-	result2, err := repository.Find(db.Role1)
+	result2, err := repository.Find(db.RoleStudent)
 	roles := result2.([]models.Role)
 
 	require.NoError(t, err)
-	require.Nil(t, deep.Equal(db.Role1.ID, roles[0].ID))
+	require.Nil(t, deep.Equal(db.RoleStudent.ID, roles[0].ID))
 }
 
 func Test_Role_GetAll(t *testing.T) {
@@ -55,19 +55,19 @@ func Test_Role_GetAll(t *testing.T) {
 	roles := result.([]models.Role)
 
 	require.NoError(t, err)
-	require.Nil(t, deep.Equal(db.Role1.ID, roles[0].ID))
-	require.Nil(t, deep.Equal(db.Role2.ID, roles[1].ID))
+	require.Nil(t, deep.Equal(db.RoleStudent.ID, roles[0].ID))
+	require.Nil(t, deep.Equal(db.RoleDozent.ID, roles[1].ID))
 }
 
 func Test_Role_GetID(t *testing.T) {
 	repository := NewRoleRepository(db.NewPrefilledMockProvider())
 
 	// Get by ID
-	result, err := repository.GetId(db.Role1.ID)
+	result, err := repository.GetId(db.RoleStudent.ID)
 	role := result.(*models.Role)
 
 	require.NoError(t, err)
-	require.Nil(t, deep.Equal(role.Description, db.Role1.Description))
+	require.Nil(t, deep.Equal(role.Description, db.RoleStudent.Description))
 }
 
 func Test_Role_DeleteId(t *testing.T) {
@@ -78,7 +78,7 @@ func Test_Role_DeleteId(t *testing.T) {
 	afterCreateLength := len(result.([]models.Role))
 
 	// Delete role
-	err := repository.DeleteId(db.Role1.ID)
+	err := repository.DeleteId(db.RoleStudent.ID)
 
 	result2, _ := repository.GetAll()
 	afterDeleteLength := len(result2.([]models.Role))


### PR DESCRIPTION
Prefilled mock data teacher list in /courses/meta is empty.
Prefilled mock data role id's differ from production role ids.
Harmonized role ids between mock data and real data.